### PR TITLE
fix: output UsableRules.csv

### DIFF
--- a/WELA.ps1
+++ b/WELA.ps1
@@ -1408,7 +1408,7 @@ function AuditLogSetting {
     }
     $usableRules     = $auditResult | Select-Object -ExpandProperty Rules | Where-Object { $_.applicable -eq $true }
     $unUsableRules   = $auditResult | Select-Object -ExpandProperty Rules | Where-Object { $_.applicable -eq $false }
-    $usableules | Select-Object title, level, id | Export-Csv -Path "UsableRules.csv" -NoTypeInformation
+    $usableRules | Select-Object title, level, id | Export-Csv -Path "UsableRules.csv" -NoTypeInformation
     $unusableRules  | Select-Object title, level, id | Export-Csv -Path "UnusableRules.csv" -NoTypeInformation
     Write-Output "Usable detection rules list saved to: UsableRules.csv"
     Write-Output "Unusable detection rules list saved to: UnusableRules.csv"


### PR DESCRIPTION
I had used an incorrect variable name, which caused the UsableRules.csv to be empty, so I fixed it.

<img width="1710" alt="スクリーンショット 2025-05-03 22 38 37" src="https://github.com/user-attachments/assets/58449e5c-89e0-4d95-b92d-4116f22f984b" />


I’d appreciate it if you could check it when you have time🙏