### PR TITLE
feat: Support Defender for Identity required logs

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -6,6 +6,7 @@
 
 - MITRE ATT&CK Navigatorヒートマップに対応した。 (#11) (@fukusuket)
 - Windows設定を様々なベースラインに構成するための`configure`コマンドを追加した。 (#12) (@fukusuket)
+- Defender for Identityの必要なログに対応した。 (#114) (@fukusuket)
 
 **バグ修正:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support for MITRE ATT&CK Navigator heatmaps. (#11) (@fukusuket)
 - Added a `configure` command to configure Windows settings to various baselines. (#12) (@fukusuket)
+- Support for Defender for Identity required logs. (#114) (@fukusuket)
 
 **Bug Fixes:**
 


### PR DESCRIPTION
Closed #114

I added the following configuration process required for Defender for Identity to the configure command.
- Account Management	Audit Computer Account Management*
- Network security: Restrict NTLM: Outgoing NTLM traffic to remote servers
- Network security: Restrict NTLM: Audit NTLM authentication in this domain
- Network security: Restrict NTLM: Audit Incoming NTLM Traffic

I’d appreciate it if you could check it when you have time🙏