### PR TITLE
chore: update action versions and adjust permissions in workflow files

### DIFF
--- a/.github/workflows/check-audit.yml
+++ b/.github/workflows/check-audit.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "*" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -12,7 +15,7 @@ jobs:
         os: [windows-latest, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check PowerShell version(PowerShell core)
         run: |
           $PSVersionTable.PSVersion

--- a/.github/workflows/create-csv.yml
+++ b/.github/workflows/create-csv.yml
@@ -3,6 +3,9 @@ name: Create auditpol_output.csv
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -10,8 +13,7 @@ jobs:
         os: [windows-2019, windows-2022, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Generate csv from auditpol /list /subcategory:* /r
         run: |
               $data = auditpol /list /subcategory:* /r

--- a/.github/workflows/create-rule-meta.yml
+++ b/.github/workflows/create-rule-meta.yml
@@ -1,7 +1,7 @@
 name: create security_rules.json
 on:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 20 1 * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-rule-meta.yml
+++ b/.github/workflows/create-rule-meta.yml
@@ -4,24 +4,28 @@ on:
     - cron: '0 20 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout self repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: WELA
 
       - name: Checkout wela-extractor
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/WELA-RulesGenerator
           path: wela-extractor
 
       - name: Checkout hayabusa-rules
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-rules
           path: hayabusa-rules
@@ -57,7 +61,7 @@ jobs:
       - name: Create Pull Request
         if: env.change_exist == 'true'
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
         with:
           path: WELA
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,7 +75,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-operation == 'created' # This only runs if there were sigma rules updates and a new PR was created.
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
@@ -79,7 +83,7 @@ jobs:
 
       - name: upload change log
         if: env.change_exist == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: changed_rule_log
           path: ${{ github.workspace }}/changed_rule.logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         default: "main"
         description: "Branch or Tag to checkout"
+
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ${{ matrix.info.os }}
@@ -22,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch_or_tag }}
           submodules: 'true'
@@ -44,14 +48,14 @@ jobs:
 
       - name: Upload Artifacts
         if: contains(matrix.info.os, 'windows') == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: release-binaries/*
 
       - name: Setup node
         if: matrix.info.os == 'macos-latest'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
 
@@ -65,7 +69,7 @@ jobs:
 
       - name: Upload Document Artifacts
         if: matrix.info.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wela-documents
           path: |


### PR DESCRIPTION
## What Changed
I have updated third-party action references to use full-length commit SHA, following the best practices.
- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

I’d appreciate it if you could check it when you have time🙏